### PR TITLE
Fix: Update caller of execute_bash_script

### DIFF
--- a/autoload/ajapopaja.py
+++ b/autoload/ajapopaja.py
@@ -172,7 +172,7 @@ class AjaPopAja:
 
     def execute_selected_code_section(self):
         extract_and_save_fenced_code(self.workspace, ".exec.sh")
-        self.git_reporter.execute_bash_script(self.workspace, ".exec.sh")
+        self.git_reporter.execute_bash_script(".exec.sh")
 
 
 @dataclass(frozen=True)

--- a/autoload/ajapopajagit.py
+++ b/autoload/ajapopajagit.py
@@ -172,31 +172,26 @@ class GitReporter:
 
     def execute_bash_script(
         self, 
-        working_directory: str,
         script_name: str):
         """
-        Executes a bash scriptin a specified working directory.
+        Executes a bash script in the repository's root directory.
 
         Args:
+            script_name (str): The name of the script to execute.
             command (str): The commands to execute in a single script like a shell script.
-            working_directory (str): The path to the directory where the command should be executed.
 
         Returns:
             subprocess.CompletedProcess: An object containing the return code,
                                          stdout, and stderr of the executed command.
 
         Raises:
-            FileNotFoundError: If the specified working_directory does not exist.
             subprocess.CalledProcessError: If check=True and the command returns a non-zero exit code.
             Exception: For other potential issues during command execution.
         """
-        if not os.path.isdir(working_directory):
-            raise FileNotFoundError(
-                f"Working directory does not exist: {working_directory}")
         try:
             result = subprocess.run(
                 f"bash {script_name}",
-                cwd=working_directory,
+                cwd=self.repo_path,
                 capture_output=True,
                 text=True,
                 check=True,


### PR DESCRIPTION
This commit updates the caller of `GitReporter.execute_bash_script` in `autoload/ajapopaja.py`. The `working_directory` argument, which was `self.workspace`, has been removed from the call.

This change is necessary because `execute_bash_script` was refactored to no longer accept `working_directory` and instead use its internal `self.repo_path` (which is initialized from `self.workspace` via the GitReporter constructor).

This ensures the `execute_selected_code_section` method in AjaPopAja continues to function as intended with the updated GitReporter.